### PR TITLE
Update React.Render() to render in div tag instead of body

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 	<link rel='stylesheet' id='js_composer_front-css'  href='/assets/css/normalize.css' type='text/css' media='all' />
 	<link rel='stylesheet' id='js_composer_front-css'  href='/assets/css/react-json.css' type='text/css' media='all' />
 <body>
+<div id="app"></div>
 <script src="/assets/bundle.js"></script>
 </script>
 </body>

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,6 @@ require('./style.scss');
 Router.run( routes, Router.HistoryLocation, function( Handler ){
 	React.render(
 		React.createElement( Handler ),
-		document.body
+		document.getElementById('app')
 	);
 });


### PR DESCRIPTION
Great example!

The only thing I would change in this example is where the `react.render()` method is rendering. Its a common best practice to render inside the `body` instead of the `body` tag directly. 

In case other people find this diff. 
https://medium.com/@dan_abramov/two-weird-tricks-that-fix-react-7cf9bbdef375

Great work, looking forward to following you on twitter. 
